### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Helpful information in : https://github.com/Lolliedieb/lolMiner-releases/wiki
 | Algorithm  | Fee % |
 | ------------- | ------------- |
 | Autolykos V2 | 1.5  | 
-| BeamHash I | 1.0  | 
-| BeamHash II | 1.0  |
 | BeamHash III | 1.0  |
 | Cuckoo 29 | 2.0  |
 | CuckarooD 29 | 2.0 |


### PR DESCRIPTION
BeamHash-I and BeamHash-II are no longer supported (taken from miner startup screen)